### PR TITLE
Build and push gem versions from VCS tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,14 +9,13 @@ A plugin for RubyGems which lets you pass in version strings via a environment v
 
 ## Installation
 
-Install it yourself as:
+Install it yourself:
 
     $ gem install gem-versioner
 
 ## Usage
 
-when you build a gem e.g. `my-gem`
-you can specify a pre release version by
+When you build a gem (e.g. `my-gem`) you can specify a pre release version by
 
     $ PRE_RELEASE=foo build my-gem.gemspec
     

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ This will build a gem with a version in the following format `${gem_version}.pre
 
 ## Publishing
 
-As soon as a new PR is merged to master CircleCI is responsible to publish the new version of the Gem to https://rubygems.org/
+When a new version is tagged and pushed, CircleCI will build and publish the new version of the gem to https://rubygems.org/gems/gem-versioner.
 
 ## Development
 

--- a/circle.yml
+++ b/circle.yml
@@ -4,9 +4,10 @@ test:
     - bundle exec pronto run --commit origin/master --exit-code
 deployment:
   rubygems:
-    branch: master
+    tag: /.+/
+    owner: FundingCircle
     commands:
-      - "gem build gem-versioner.gemspec"
+      - "gem build $CIRCLE_PROJECT_REPONAME.gemspec"
       - 'echo :rubygems_api_key: ${RUBYGEMS_API_KEY} >  ~/.gem/credentials'
       - "chmod 0600 ~/.gem/credentials"
-      - "gem push gem-versioner-*.gem"
+      - "gem push $CIRCLE_PROJECT_REPONAME-*.gem"


### PR DESCRIPTION
💁  Automatically pushing gem versions on merge to master makes it difficult to merge changes - they explicitly will require the gem version to be bumped, which is not always required. Making the process of building and pushing gems to RubyGems reliant on a tag in version control also means
that any version of this gem will be explicitly linked to a version control tag.

Example from https://circleci.com/gh/FundingCircle/gem-versioner/27
```
$ gem push gem-versioner-*.gem
Pushing gem to https://rubygems.org...
Repushing of gem versions is not allowed.
Please use `gem yank` to remove bad gem releases.

gem push gem-versioner-*.gem returned exit code 1

Action failed: gem push gem-versioner-*.gem
```

These changes update the CircleCI configuration to build and push gem versions when a new VCS tag is created.