### PR TITLE
Update tag filters

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -116,9 +116,15 @@ workflows:
   multiple-ruby-versions:
     jobs:
       - pronto:
+          filters:
+            tags:
+              only: /.*/
           image-tag: "2.6-alpine"
           name: pronto
       - rubocop:
+          filters:
+            tags:
+              only: /.*/
           image-tag: "2.6-alpine"
           name: rubocop
       - tests:


### PR DESCRIPTION
💁 I missed this in #12. The `publish-gem` job won't be triggered unless there is a `filters.tags` key set in every job it depends on.

From the [relevant CircleCI documentation](https://circleci.com/docs/2.0/workflows/#executing-workflows-for-a-git-tag):

> CircleCI does not run workflows for tags unless you explicitly specify tag filters. Additionally, if a job requires any other jobs (directly or indirectly), you must use regular expressions to specify tag filters for those jobs. Both lightweight and annotated tags are supported.